### PR TITLE
添加了holo样式边框的宽度属性

### DIFF
--- a/wheelview/src/main/java/com/wx/wheelview/graphics/HoloDrawable.java
+++ b/wheelview/src/main/java/com/wx/wheelview/graphics/HoloDrawable.java
@@ -45,7 +45,7 @@ public class HoloDrawable extends WheelDrawable {
                 .WHEEL_SKIN_HOLO_BG);
 
         mHoloPaint = new Paint();
-        mHoloPaint.setStrokeWidth(3);
+        mHoloPaint.setStrokeWidth(mStyle.holoBorderWidth != -1 ? mStyle.holoBorderWidth : 3);
         mHoloPaint.setColor(mStyle.holoBorderColor != -1 ? mStyle.holoBorderColor : WheelConstants
                 .WHEEL_SKIN_HOLO_BORDER_COLOR);
     }

--- a/wheelview/src/main/java/com/wx/wheelview/widget/WheelView.java
+++ b/wheelview/src/main/java/com/wx/wheelview/widget/WheelView.java
@@ -678,6 +678,7 @@ public class WheelView<T> extends ListView implements IWheelView<T> {
 
         public int backgroundColor = -1; // 背景颜色
         public int holoBorderColor = -1;   // holo样式边框颜色
+        public int holoBorderWidth = -1;//holo样式边框宽度
         public int textColor = -1; // 文本颜色
         public int selectedTextColor = -1; // 选中文本颜色
         public int textSize = -1;// 文本大小
@@ -691,6 +692,7 @@ public class WheelView<T> extends ListView implements IWheelView<T> {
         public WheelViewStyle(WheelViewStyle style) {
             this.backgroundColor = style.backgroundColor;
             this.holoBorderColor = style.holoBorderColor;
+            this.holoBorderWidth = style.holoBorderWidth;
             this.textColor = style.textColor;
             this.selectedTextColor = style.selectedTextColor;
             this.textSize = style.textSize;


### PR DESCRIPTION
1、在WheelViewStyle中添加了属性holoBorderWidth(holo样式边框的宽度)属性
2、在HoloDrawable的init方法中，修改mHoloPaint.setStrokeWidth(3)为
mHoloPaint.setStrokeWidth(mStyle.holoBorderWidth != -1 ? mStyle.holoBorderWidth : 3);